### PR TITLE
fix: ensure data directories exist before access

### DIFF
--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"database/sql"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -16,6 +17,9 @@ type DBStore struct {
 const DB_FILEPATH = "db.sqlite"
 
 func NewDBStore(basePath string) (*DBStore, error) {
+	if err := os.MkdirAll(basePath, 0755); err != nil {
+		return nil, err
+	}
 	dbFilePath := filepath.Join(basePath, DB_FILEPATH)
 	db, err := sql.Open("sqlite", dbFilePath)
 	if err != nil {

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -18,6 +20,24 @@ func TestNew(t *testing.T) {
 
 	if store.db == nil {
 		t.Error("New() returned store with nil db")
+	}
+}
+
+func TestNewDBStore_CreatesDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+	nonExistentDir := filepath.Join(tempDir, "subdir")
+	if _, err := os.Stat(nonExistentDir); !os.IsNotExist(err) {
+		t.Fatalf("setup: expected %s to not exist", nonExistentDir)
+	}
+
+	store, err := NewDBStore(nonExistentDir)
+	if err != nil {
+		t.Fatalf("NewDBStore() with non-existent dir failed: %v", err)
+	}
+	defer store.Close()
+
+	if _, err := os.Stat(nonExistentDir); os.IsNotExist(err) {
+		t.Errorf("NewDBStore() did not create directory %s", nonExistentDir)
 	}
 }
 

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -27,6 +27,9 @@ func NewSyncer(root string, db *storage.DBStore) *Syncer {
 }
 
 func (s *Syncer) Sync() error {
+	if err := os.MkdirAll(s.Root, 0755); err != nil {
+		return err
+	}
 	return filepath.WalkDir(s.Root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err


### PR DESCRIPTION
Prevent 'unable to open database file' crash on first run by recursively creating the database and journal directories if they do not exist.